### PR TITLE
[fix] Conflict with ofx import OCA module

### DIFF
--- a/wizard/account_bank_statement_import_csv.py
+++ b/wizard/account_bank_statement_import_csv.py
@@ -32,7 +32,9 @@ class AccountBankStatementImport(models.TransientModel):
             return False
         if not unicodecsv:
             return False
-        try:
+        try:            
+            if not data_file.name.enswith('.csv'):
+                return False
             csv = unicodecsv.DictReader(data_file, delimiter=',', quotechar='"',
                                          encoding='utf-8')
         except Exception as e:


### PR DESCRIPTION
Hello,
I suggest this change on your module, it allows to setup oca/bank-statement-import/account_bank_statement_import_ofx module on the same odoo.

If there isn't this line, when we try to import ofx, the CSV code is activated and we finally get this error:

> The following problem occurred during import. The file might not be valid:
> 
> entry_date